### PR TITLE
Update nvm cURL link

### DIFF
--- a/setup.Rmd
+++ b/setup.Rmd
@@ -124,7 +124,7 @@ The best way to install Node is to use [**`nvm`**](https://github.com/nvm-sh/nvm
 ## Run from your home directory:
 
 touch ~/.bash_profile
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
 
 ## Restart the command shell
 


### PR DESCRIPTION
I was reinstalling nvm on a new machine a few days ago and ran into an error since the version number posted in the book is a little behind the newest one. 

Pulled the newest version from here: https://github.com/nvm-sh/nvm
