### PR TITLE
Fix formatting issues in css-layout.Rmd

### DIFF
--- a/build/ajax.html
+++ b/build/ajax.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/client-side-development.html
+++ b/build/client-side-development.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/client-side-routing.html
+++ b/build/client-side-routing.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/css-frameworks.html
+++ b/build/css-frameworks.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/css-in-js.html
+++ b/build/css-in-js.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/css-layouts.html
+++ b/build/css-layouts.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -410,10 +410,12 @@
             <section class="normal" id="section-">
 <div id="css-layouts" class="section level1">
 <h1><span class="header-section-number">Chapter 7</span> CSS Layouts</h1>
-<p>The previous chapters have discussed how to use CSS to specify the appearance of individual html elements (e.g., text size, color, backgrounds, etc). This chapter details how to use CSS to declare where HTML elements should <em>appear</em> on a web page!Placing elements exactly how you want them can be surprisingly difficult. Elements are arranged from the <strong>top left corner</strong> of the page, and are arranged based on three related (but distinct) concepts:
-- <strong>Display</strong>: determines how elements share horizontal space
-- <strong>Position</strong>: allows you to adjust the location of the natural flow of elements
-- <strong>Box-model</strong>: describes the amount of 2D space taken up by an element, and how much space is between elements</p>
+<p>The previous chapters have discussed how to use CSS to specify the appearance of individual html elements (e.g., text size, color, backgrounds, etc). This chapter details how to use CSS to declare where HTML elements should <em>appear</em> on a web page! Placing elements exactly how you want them can be surprisingly difficult. Elements are arranged from the <strong>top left corner</strong> of the page, and are arranged based on three related (but distinct) concepts:</p>
+<ul>
+<li><p><strong>Display</strong>: determines how elements share horizontal space</p></li>
+<li><p><strong>Position</strong>: allows you to adjust the location of the natural flow of elements</p></li>
+<li><p><strong>Box-model</strong>: describes the amount of 2D space taken up by an element, and how much space is between elements</p></li>
+</ul>
 <div id="display" class="section level2">
 <h2><span class="header-section-number">7.1</span> Display</h2>
 <p>Without any CSS, html elements follow a default <strong>flow</strong> on the page based on the order they appear in the HTML. Layout is based on whether the element is a <em>block element</em> or an <em>inline element</em>.</p>

--- a/build/css-options.html
+++ b/build/css-options.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/css.html
+++ b/build/css.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/dom.html
+++ b/build/dom.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/es6.html
+++ b/build/es6.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/firebase.html
+++ b/build/firebase.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/functional-programming.html
+++ b/build/functional-programming.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/html-fundamentals.html
+++ b/build/html-fundamentals.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/index.html
+++ b/build/index.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/interactive-react.html
+++ b/build/interactive-react.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/javascript-libraries.html
+++ b/build/javascript-libraries.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/javascript.html
+++ b/build/javascript.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/jest.html
+++ b/build/jest.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/machine-setup.html
+++ b/build/machine-setup.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/react-native.html
+++ b/build/react-native.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/react.html
+++ b/build/react.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/redux.html
+++ b/build/redux.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/responsive-css.html
+++ b/build/responsive-css.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/standards-and-accessibility.html
+++ b/build/standards-and-accessibility.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/build/webpack.html
+++ b/build/webpack.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-10">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/css-layout.Rmd
+++ b/css-layout.Rmd
@@ -1,8 +1,11 @@
 # CSS Layouts
 
-The previous chapters have discussed how to use CSS to specify the appearance of individual html elements (e.g., text size, color, backgrounds, etc). This chapter details how to use CSS to declare where HTML elements should _appear_ on a web page!Placing elements exactly how you want them can be surprisingly difficult. Elements are arranged from the **top left corner** of the page, and are arranged based on three related (but distinct) concepts:
+The previous chapters have discussed how to use CSS to specify the appearance of individual html elements (e.g., text size, color, backgrounds, etc). This chapter details how to use CSS to declare where HTML elements should _appear_ on a web page! Placing elements exactly how you want them can be surprisingly difficult. Elements are arranged from the **top left corner** of the page, and are arranged based on three related (but distinct) concepts:
+
 - **Display**: determines how elements share horizontal space
+
 - **Position**: allows you to adjust the location of the natural flow of elements
+
 - **Box-model**: describes the amount of 2D space taken up by an element, and how much space is between elements
 
 ## Display


### PR DESCRIPTION
The commits in this pull request resolve two issues with the introductory paragraph in `css-layout.Rmd`:

1. Missing space between `...where HTML elements should appear on a web page!` and `Placing elements exactly how you want them...`

2. Bullet points not expanded into an unordered list

Screenshots demonstrating this PR's effect are attached at the end.

I hope the HTML files under the `build` directory were updated properly. I had to use newer versions of the dependency packages to generate the book: `Rcpp` 0.12.2 could not be compiled on my machine with GCC 10 so I was forced to use 1.0.5, the latest version. Some other dependencies also had their version bumped because of `Rcpp`. They would tinker with not only the dates but also syntax for some HTML tags, like ending `<meta>` tags with `/>` rather than pure `>`.

After examining some past commits (e.g. a0384177853894537c9c0118690b98d3efbc9863) I realized the changes I had got was probably too big, so I decided not to check everything into Git but only add the new dates and the paragraph with formatting issues fixed. This is why I divided everything into multiple small commits: if I messed up, you can just pick the first commit (e371908) which only touches the source `.Rmd` file and then re-generate `build/*.html` in your environment where everything is supposed to work without updating dependencies. Otherwise, you may squash these commits into a single one if having 3 commits for only one change is too much.

I am happy to provide a complete `diff` for the changes I got upon request, should the dependency problem be worth investigating.

---

Before:

<img width="640" alt="The paragraph concerned before fix" src="https://user-images.githubusercontent.com/14175175/95668330-5e615800-0b27-11eb-9adb-92d34ddaa91e.png">

After:

<img width="640" alt="The paragraph concerned after fix" src="https://user-images.githubusercontent.com/14175175/95668331-5e615800-0b27-11eb-8178-dea2d81a5ebd.png">

