### PR TITLE
Fix a Typo in javascript.Rmd

### DIFF
--- a/build/javascript.html
+++ b/build/javascript.html
@@ -25,7 +25,7 @@
 <meta name="author" content="Joel Ross and Mike Freeman">
 
 
-<meta name="date" content="2019-09-26">
+<meta name="date" content="2020-10-22">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -531,7 +531,7 @@ console<span class="token punctuation">.</span><span class="token function">log<
 </div>
 <div id="variables" class="section level2">
 <h2><span class="header-section-number">10.4</span> Variables</h2>
-<p>Variables in JavaScript are <strong>dynamically typed</strong>. This means that variables are not <em>not</em> declared as a particular type (e.g., <code>int</code> or <code>String</code>), but instead take on the data type (<code>Number</code>, <code>String</code>, etc.) of the <em>value</em> currently assigned to that variable. As we don’t specify the data type, JavaScript variables are declared using the <code>let</code> keyword:</p>
+<p>Variables in JavaScript are <strong>dynamically typed</strong>. This means that variables are <em>not</em> declared as a particular type (e.g., <code>int</code> or <code>String</code>), but instead take on the data type (<code>Number</code>, <code>String</code>, etc.) of the <em>value</em> currently assigned to that variable. As we don’t specify the data type, JavaScript variables are declared using the <code>let</code> keyword:</p>
 <pre class="language-js"><code><span class="token keyword">let</span> message <span class="token operator">=</span> <span class="token string">'Hello World'</span><span class="token punctuation">;</span>  <span class="token comment">//a String</span>
 console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span><span class="token keyword">typeof</span> message<span class="token punctuation">)</span><span class="token punctuation">;</span>  <span class="token comment">//=> `string`</span>
 

--- a/javascript.Rmd
+++ b/javascript.Rmd
@@ -134,7 +134,7 @@ You declare that a script or function should be executed in strict mode by putti
 
 
 ## Variables
-Variables in JavaScript are **dynamically typed**. This means that variables are not _not_ declared as a particular type (e.g., `int` or `String`), but instead take on the data type (`Number`, `String`, etc.) of the _value_ currently assigned to that variable. As we don't specify the data type, JavaScript variables are declared using the `let` keyword:
+Variables in JavaScript are **dynamically typed**. This means that variables are _not_ declared as a particular type (e.g., `int` or `String`), but instead take on the data type (`Number`, `String`, etc.) of the _value_ currently assigned to that variable. As we don't specify the data type, JavaScript variables are declared using the `let` keyword:
 
 ```js
 let message = 'Hello World';  //a String


### PR DESCRIPTION
This pull request contains a patch that removes a duplicate `not` in `javascript.Rmd`, located in section 10.4.

![Screenshot from 2020-10-22 13-36-03](https://user-images.githubusercontent.com/14175175/96927387-d3a82380-146b-11eb-8b15-c026497ea14c.png)

I didn't want to go through the same ordeal of filtering which changes in `build/*.html` were caused by different dependency versions I used, which I had described in [a previous PR of mine](https://github.com/info340/book/pull/9). Thus, this time I only included relevant change in the corresponding HTML document of `javascript.Rmd`.